### PR TITLE
Bump project version to 1.2.x

### DIFF
--- a/src/RouteDispatcher/RouteDispatcher.csproj
+++ b/src/RouteDispatcher/RouteDispatcher.csproj
@@ -49,7 +49,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <Version>$([System.String]::Format('1.1.{0}', $(CurrentVersion)))</Version>
+      <Version>$([System.String]::Format('1.2.{0}', $(CurrentVersion)))</Version>
       <PackageVersion>$(Version)</PackageVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
Updated the project version format from 1.1.x to 1.2.x in the RouteDispatcher.csproj file. This prepares for the next release cycle with incremented versioning.